### PR TITLE
feat: NormalUser api CRUD 구현하였습니다.

### DIFF
--- a/src/main/java/com/woowahan/moduchan/ModuChanApplication.java
+++ b/src/main/java/com/woowahan/moduchan/ModuChanApplication.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class ModuChanApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ModuChanApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ModuChanApplication.class, args);
+    }
 }

--- a/src/main/java/com/woowahan/moduchan/config/SecurityConfig.java
+++ b/src/main/java/com/woowahan/moduchan/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.woowahan.moduchan.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/woowahan/moduchan/controller/ApiUserController.java
+++ b/src/main/java/com/woowahan/moduchan/controller/ApiUserController.java
@@ -18,6 +18,7 @@ public class ApiUserController {
     // TODO: 2018. 8. 14. getAllUsers: normalUser + adminUser가 필요하지 않을까?
     // TODO: 2018. 8. 14. create에 들어오는 request body와 update로 들어오는
     // request body에서 내용물이 다른데, @valid가 두 경우 모두 커버할 수 있을지?
+    // TODO: 2018. 8. 15. UserApi가 언제 호출되는지, 호출의 권한에 대하여 논의해볼 필요가 있습니다.
 
     @GetMapping("")
     public ResponseEntity<List<UserDTO>> getNormalUsers() {
@@ -30,19 +31,22 @@ public class ApiUserController {
     }
 
     @PostMapping("")
-    public ResponseEntity<Void> createUser(@RequestBody UserDTO userDTO) {
-
-        return null;
+    public ResponseEntity<Void> createNormalUser(@RequestBody UserDTO userDTO) {
+        // TODO: 2018. 8. 15. Need validation & duplication check
+        userService.createNormalUser(userDTO);
+        return new ResponseEntity<Void>(HttpStatus.CREATED);
     }
 
     @DeleteMapping("/{uid}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long uid) {
+    public ResponseEntity<Void> deleteNormalUser(@PathVariable Long uid) {
         userService.deleteNormalUserById(uid);
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     @PutMapping("")
-    public ResponseEntity<Void> updateUser(@RequestBody UserDTO userDTO) {
-        return null;
+    public ResponseEntity<Void> updateNormalUser(@RequestBody UserDTO userDTO) {
+        // FIXME: 2018. 8. 15. 세션에 기록된 id를 이용해서 DB로부터 유저를 꺼내어 정보 갱신을 해야합니다.
+        userService.updateNormalUser(userDTO);
+        return new ResponseEntity<Void>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/woowahan/moduchan/controller/ProjectController.java
+++ b/src/main/java/com/woowahan/moduchan/controller/ProjectController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class ProjectController {
     @GetMapping("/aa")
-    public String list(){
+    public String list() {
         return "";
     }
 }

--- a/src/main/java/com/woowahan/moduchan/domain/project/Project.java
+++ b/src/main/java/com/woowahan/moduchan/domain/project/Project.java
@@ -1,6 +1,5 @@
 package com.woowahan.moduchan.domain.project;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.woowahan.moduchan.domain.category.Category;
 import com.woowahan.moduchan.domain.product.Product;
 import com.woowahan.moduchan.domain.user.NormalUser;
@@ -12,6 +11,30 @@ import java.util.List;
 
 @Entity
 public class Project extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /* 프로젝트 정보 */
+    private String title;
+    @Lob
+    private String description;
+    private String thumbnailUrl;
+    /* 모금 */
+    private Long goalFundRaising;
+    /* 시간 */
+    private Date startAt;
+    private Date endAt;
+    /* 사람 */
+    @ManyToOne
+    @JoinColumn
+    private NormalUser owner;
+    private STATUS status;
+    @ManyToOne
+    @JoinColumn
+    private Category category;
+    @OneToMany(mappedBy = "project")
+    private List<Product> products;
+
     public enum STATUS {
         DRAFT,
         EVALUATING,
@@ -20,35 +43,4 @@ public class Project extends BaseTimeEntity {
         COMPLETE,
         INCOMPLETE
     }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    /* 프로젝트 정보 */
-    private String title;
-    @Lob
-    private String description;
-    private String thumbnailUrl;
-
-    /* 모금 */
-    private Long goalFundRaising;
-
-    /* 시간 */
-    private Date startAt;
-    private Date endAt;
-
-    /* 사람 */
-    @ManyToOne
-    @JoinColumn
-    private NormalUser owner;
-
-    private STATUS status;
-
-    @ManyToOne
-    @JoinColumn
-    private Category category;
-
-    @OneToMany(mappedBy = "project")
-    private List<Product> products;
 }

--- a/src/main/java/com/woowahan/moduchan/domain/user/NormalUser.java
+++ b/src/main/java/com/woowahan/moduchan/domain/user/NormalUser.java
@@ -1,13 +1,14 @@
 package com.woowahan.moduchan.domain.user;
 
 import com.woowahan.moduchan.dto.UserDTO;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Entity;
 
 @Entity
+@NoArgsConstructor
 public class NormalUser extends User {
     private String phoneNo;
     private String address;
@@ -19,12 +20,31 @@ public class NormalUser extends User {
         this.address = address;
     }
 
+    public static NormalUser from(UserDTO userDTO) {
+        NormalUserBuilder normalUserBuilder = new NormalUserBuilder();
+        return normalUserBuilder
+                .password(userDTO.getPassword())
+                .email(userDTO.getEmail())
+                .name(userDTO.getName())
+                .phoneNo(userDTO.getPhoneNo())
+                .address(userDTO.getAddress())
+                .build();
+    }
+
     public UserDTO toDTO() {
         return new UserDTO(id, password, email, name, phoneNo, address);
     }
 
-    public static NormalUser from(UserDTO userDTO) {
-        NormalUserBuilder normalUserBuilder = new NormalUserBuilder();
-        return null;
+    public NormalUser encryptPassword(PasswordEncoder passwordEncoder) {
+        password = passwordEncoder.encode(password);
+        return this;
+    }
+
+    public NormalUser update(UserDTO userDTO) {
+        email = userDTO.getEmail();
+        name = userDTO.getName();
+        phoneNo = userDTO.getPhoneNo();
+        address = userDTO.getAddress();
+        return this;
     }
 }

--- a/src/main/java/com/woowahan/moduchan/domain/user/User.java
+++ b/src/main/java/com/woowahan/moduchan/domain/user/User.java
@@ -1,8 +1,11 @@
 package com.woowahan.moduchan.domain.user;
 
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @MappedSuperclass
+@NoArgsConstructor
 public abstract class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,13 +18,13 @@ public abstract class User {
 
     protected boolean deleted = false;
 
-    public void delete() {
-        this.deleted = true;
-    }
-
     public User(String password, String email, String name) {
         this.password = password;
         this.email = email;
         this.name = name;
+    }
+
+    public void delete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/woowahan/moduchan/repository/NormalUserRepository.java
+++ b/src/main/java/com/woowahan/moduchan/repository/NormalUserRepository.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface NormalUserRepository extends JpaRepository<NormalUser, Long> {
+    public List<NormalUser> findAllByDeletedFalse();
 
-    public List<NormalUser> findAllByDeletedNot();
+    public Optional<NormalUser> findByIdAndDeletedFalse(Long id);
 
-    public Optional<NormalUser> findByIdAndDeletedNot(Long id);
-
-
+    // FIXME: 2018. 8. 15. will be deprecated
+    public Optional<NormalUser> findByEmailAndDeletedFalse(String email);
 }

--- a/src/main/java/com/woowahan/moduchan/service/UserService.java
+++ b/src/main/java/com/woowahan/moduchan/service/UserService.java
@@ -4,6 +4,7 @@ import com.woowahan.moduchan.domain.user.NormalUser;
 import com.woowahan.moduchan.dto.UserDTO;
 import com.woowahan.moduchan.repository.NormalUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -15,24 +16,39 @@ public class UserService {
     @Autowired
     private NormalUserRepository normalUserRepository;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     public List<UserDTO> findAllNomalUser() {
         // TODO: 2018. 8. 14. 만약에 아무 유저도 없는 경우에는 에러로 처리할 것인가 그냥 반환할 것인가?
-        return normalUserRepository.findAllByDeletedNot().stream()
+        return normalUserRepository.findAllByDeletedFalse().stream()
                 .map(normalUser -> normalUser.toDTO().erasePassword())
                 .collect(Collectors.toList());
     }
 
     public UserDTO findNormalUserById(Long uid) {
         // TODO: 2018. 8. 14. CustomError: UserNotFound
-        return normalUserRepository.findByIdAndDeletedNot(uid)
+        return normalUserRepository.findByIdAndDeletedFalse(uid)
                 .map(normalUser -> normalUser.toDTO().erasePassword())
                 .orElseThrow(RuntimeException::new);
+    }
+
+    public void createNormalUser(UserDTO userDTO) {
+        normalUserRepository.save(NormalUser.from(userDTO).encryptPassword(passwordEncoder));
+    }
+
+    public void updateNormalUser(UserDTO userDTO) {
+        // FIXME: 2018. 8. 15. 세션에 기록된 id를 이용해서 DB로부터 유저를 꺼내어 정보 갱신을 해야합니다.
+        // TODO: 2018. 8. 14. CustomError: UserNotFound
+        normalUserRepository.save(
+                normalUserRepository.findByEmailAndDeletedFalse(userDTO.getEmail())
+                        .orElseThrow(RuntimeException::new).update(userDTO));
     }
 
     @Transactional
     public void deleteNormalUserById(Long uid) {
         // TODO: 2018. 8. 14. CustomError: UserNotFound
-        normalUserRepository.findByIdAndDeletedNot(uid)
+        normalUserRepository.findByIdAndDeletedFalse(uid)
                 .orElseThrow(RuntimeException::new).delete();
     }
 }


### PR DESCRIPTION
1. 사용자 생성시 Bcrypt를 이용하여 비밀번호를 암호화합니다.
2. 사용자 정보 갱신시 request body로 전달되는 email값을 이용하여
   데이터베이스에서 원본 사용자 정보를 가져와 갱신합니다.
   -  FIXME: 세션 정보를 이용하여 권한 검증 후 갱신하도록 합니다.

#33 유저API컨트롤러 구현

TODO:
    - #39 사용자 API 별로 권한 검증 루틴이 필요합니다.