### PR TITLE
fix: Divide getCategoryPage at ApiCategoryController

### DIFF
--- a/src/main/java/com/woowahan/moduchan/controller/ApiCategoryController.java
+++ b/src/main/java/com/woowahan/moduchan/controller/ApiCategoryController.java
@@ -48,7 +48,17 @@ public class ApiCategoryController {
             //error에 대한 설명 추가
     })
     @GetMapping("/{cid}/last/{lastIndex}")
-    public ResponseEntity<List<ProjectDTO>> getCategoryPage(@PathVariable("cid") Long cid, @PathVariable("lastIndex") Long lastIndex) {
-        return new ResponseEntity<>(categoryService.getCategoryPage(cid, lastIndex), HttpStatus.OK);
+    public ResponseEntity<List<ProjectDTO>> getProjectsOfOneCategory(@PathVariable Long cid, @PathVariable Long lastIndex) {
+        return new ResponseEntity<>(categoryService.getProjectsOfOneCategory(cid, lastIndex), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "전체 카테고리 특정 페이지의 프로젝트 조회", notes = "특정 페이지의 프로젝트 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "조회 성공")
+            //error에 대한 설명 추가
+    })
+    @GetMapping("/all/last/{lastIndex}")
+    public ResponseEntity<List<ProjectDTO>> getProjectsOfAllCategory(@PathVariable Long lastIndex) {
+        return new ResponseEntity<>(categoryService.getProjectsOfAllCategory(lastIndex), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/woowahan/moduchan/service/CategoryService.java
+++ b/src/main/java/com/woowahan/moduchan/service/CategoryService.java
@@ -33,14 +33,7 @@ public class CategoryService {
                 .toDTO();
     }
 
-    public List<ProjectDTO> getCategoryPage(Long cid, Long lastIndex) {
-        if (cid == 0) {
-            return getProjectsOfAllCategory(lastIndex);
-        }
-        return getProjectsOfOneCategory(cid, lastIndex);
-    }
-
-    private List<ProjectDTO> getProjectsOfAllCategory(Long lastIndex) {
+    public List<ProjectDTO> getProjectsOfAllCategory(Long lastIndex) {
         if (lastIndex == 0) {
             return projectRepository.findTop9ByOrderByIdDesc()
                     .stream().map(project -> project.toDTO()).collect(Collectors.toList());
@@ -49,7 +42,7 @@ public class CategoryService {
                 .stream().map(project -> project.toDTO()).collect(Collectors.toList());
     }
 
-    private List<ProjectDTO> getProjectsOfOneCategory(Long cid, Long lastIndex) {
+    public List<ProjectDTO> getProjectsOfOneCategory(Long cid, Long lastIndex) {
         if (lastIndex == 0) {
             return projectRepository.findTop9ByCategoryOrderByIdDesc(categoryRepository.findById(cid).orElseThrow(RuntimeException::new))
                     .stream().map(project -> project.toDTO()).collect(Collectors.toList());

--- a/src/main/resources/static/js/category.js
+++ b/src/main/resources/static/js/category.js
@@ -1,15 +1,19 @@
 class CategoryManager {
     constructor() {
         this.categories = {};
-        this.currentCid = 0;
+        this.currentCid = "all";
         this.ulTag = $(".categories");
         getData("/api/categories", this.categoriesCallback.bind(this));
+        getData("/api/categories/all/last/0", this.categoryProjectCallback.bind(this));
         addEventListenerToTarget(this.ulTag, "click", this.liClickHandler.bind(this));
         addEventListenerToTarget($("#more_project_btn"), "click", this.projectsMoreViewHandler.bind(this));
     }
 
     fillCategoryContentHTML(category) {
         let categoryTemplate = `<li data-category-id="{id}"><img src="{categoryImageUrl}"><p>{title}</p></li>`;
+        if (category.id === 0) {
+            category.id = "all";
+        }
         return categoryTemplate.replace(/{id}/g, category.id)
             .replace(/{categoryImageUrl}/g, category.categoryImageUrl)
             .replace(/{title}/g, category.title);
@@ -28,8 +32,6 @@ class CategoryManager {
         response.json().then(res => {
             this.insertCategoriesContentHTML(res);
             addClassName("on", this.ulTag.firstElementChild);
-        }).then(() => {
-            getData("/api/categories/" + this.currentCid + "/last/0", this.categoryProjectCallback.bind(this));
         })
     }
 
@@ -69,7 +71,6 @@ class CategoryManager {
 
     projectsMoreViewHandler(evt) {
         evt.preventDefault();
-
         this.categories[this.currentCid].projectsMoreViewApiManager(this.currentCid);
     }
 


### PR DESCRIPTION
1. getProjectsOfAllCategory: 전체 카테고리의 프로젝트 보기
  - url: /api/categories/all/last/{lastIndex}
2. getProjectsOfOneCategory: 단일 카테고리별 프로젝트 보기
  - url: /api/categories/{cid}/last/{lastIndex}